### PR TITLE
Prevent non-existent method errors

### DIFF
--- a/Indexer/OrmIndexer.php
+++ b/Indexer/OrmIndexer.php
@@ -242,7 +242,10 @@ class OrmIndexer implements IndexerInterface
         $content = '';
         foreach (array_keys(array_slice($fields, 1)) as $field) {
             $func = 'get' . ucfirst($field);
-            $content .= $element->$func() . self::SPACER;
+            
+            if (method_exists($element, $func)) {
+                $content .= $element->$func() . self::SPACER;
+            }
         }
 
         return $content;


### PR DESCRIPTION
Prevent indexer from trying to call undefined methods on objects.
